### PR TITLE
fix for policy requirement

### DIFF
--- a/endpoint.tf
+++ b/endpoint.tf
@@ -57,26 +57,15 @@ data "archive_file" "endpoint" {
   output_path = "${path.module}/builds/endpoint.zip"
 }
 
-resource "aws_lambda_permission" "public_invoke" {
-  statement_id           = "FunctionURLAllowPublicAccess"
-  principal              = "*"
-  action                 = "lambda:InvokeFunctionUrl"
-  function_name          = aws_lambda_function.endpoint.function_name
-  qualifier              = aws_lambda_alias.endpoint.name
-  function_url_auth_type = "NONE"
-}
 
-# In 2025, AWS added the requirement for the `lambda:InvokeFunction`
-# permission in order for public function URLs to work.
-# This is in addition to the existing `lambda:InvokeFunctionUrl` permission.
-# Reference: https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html#urls-auth-none
-resource "aws_lambda_permission" "public_invoke_2025" {
-  statement_id           = "FunctionURLAllowPublicAccess2025"
-  principal              = "*"
-  action                 = "lambda:InvokeFunction"
-  function_name          = aws_lambda_function.endpoint.function_name
-  qualifier              = aws_lambda_alias.endpoint.name
-  function_url_auth_type = "NONE"
+resource "aws_lambda_permission" "public_invoke" {
+  statement_id             = "FunctionURLAllowPublicAccess"
+  principal                = "*"
+  action                   = "lambda:InvokeFunctionUrl"
+  function_name            = aws_lambda_function.endpoint.function_name
+  qualifier                = aws_lambda_alias.endpoint.name
+  function_url_auth_type   = "NONE"
+  invoked_via_function_url = true
 }
 
 # The lambda module does not support an alias (only version) for

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,7 +9,7 @@ data "aws_region" "current" {}
 
 locals {
   account_id = data.aws_caller_identity.current.account_id
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
   prefix     = "rd01" # customize this
 }
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   account_id        = data.aws_caller_identity.current.account_id
-  region            = data.aws_region.current.name
+  region            = data.aws_region.current.region
   metrics_namespace = "gsuite-logs-channeler"
 }
 

--- a/modules/athena/main.tf
+++ b/modules/athena/main.tf
@@ -3,7 +3,7 @@ data "aws_region" "current" {}
 
 locals {
   account_id     = data.aws_caller_identity.current.account_id
-  region         = data.aws_region.current.name
+  region         = data.aws_region.current.region
   s3_bucket_arn  = "arn:aws:s3:::${var.s3_bucket_name}"
   table_location = join("/", compact([var.s3_prefix, var.table_name]))
   resource_name  = "${var.prefix}-gsuite-admin-reports-${var.table_name}"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0"
+      version = ">= 6.28.0"
     }
     archive = {
       source = "hashicorp/archive"


### PR DESCRIPTION
follow-up to: https://github.com/ryandeivert/terraform-aws-gsuite-reports-channeler/pull/17

^ the above was not supported by the terraform aws provider at the time, so this change should resolve that